### PR TITLE
fix: Run size check on correct destination directory

### DIFF
--- a/src/nanopore_sync/sync.py
+++ b/src/nanopore_sync/sync.py
@@ -47,7 +47,7 @@ def sync_run(source: Path) -> None:
         LOGGER.error(f"Unable to copy run '{source.name}': {exc}")
         return
 
-    if CONFIG.verify and (_ssize := _dir_size(source)) != (_dsize := _dir_size(destination / source.name)):
+    if CONFIG.verify and (_ssize := _dir_size(source)) != (_dsize := _dir_size(destination)):
         LOGGER.warning(f"Size mismatch for run '{source.name}': source size {_ssize}, destination size {_dsize}.")
         return
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,7 +24,7 @@ async def test_sync(tmp_path: Path) -> None:
         *("python", "-m", "nanopore_sync"),
         *("--source", str(input)),
         *("--destination", str(output)),
-        "--no-verify",
+        "--verify",
     ]
     proc = await aio.subprocess.create_subprocess_exec(
         *cmdline,
@@ -35,10 +35,10 @@ async def test_sync(tmp_path: Path) -> None:
     await aio.sleep(0.5)
     (input / "20231001_1200_run_a_12345678").mkdir()
     await aio.sleep(0.1)
-    (input / "20231001_1200_run_a_12345678" / "a.txt").touch()
-    (input / "20231001_1200_run_a_12345678" / "b.txt").touch()
+    (input / "20231001_1200_run_a_12345678" / "a.txt").write_text("SOME DATA")
+    (input / "20231001_1200_run_a_12345678" / "b.txt").write_text("SOME MORE DATA")
     (input / "20231001_1200_run_a_12345678" / "c").mkdir()
-    (input / "20231001_1200_run_a_12345678" / "c" / "d.txt").touch()
+    (input / "20231001_1200_run_a_12345678" / "c" / "d.txt").write_text("EVEN MORE DATA")
     await aio.sleep(0.1)
     (input / "20231001_1200_run_a_12345678" / "final_summary.txt").touch()
     await aio.sleep(0.1)
@@ -57,6 +57,7 @@ async def test_sync(tmp_path: Path) -> None:
 
     # Verify that the run was synced successfully
     assert "Run '20231001_1200_run_a_12345678' synced successfully." in logs
+    assert "Size missmatch for run '20231001_1200_run_a_12345678'" not in logs
     assert (output / "20231001_1200_run_a_12345678").exists()
     for path in ["a.txt", "b.txt", "c/d.txt"]:
         assert (output / "20231001_1200_run_a_12345678" / path).exists()


### PR DESCRIPTION
## Contents

### The What

Fixes the destination path used to verify the size of the destination directory after syncing.

### The Why

Size check ran on the wrong path, so it would always fail.

### The How

- Replaces `destination / source.name` with just `destination` as this is now the full destination path.
- Writes some data to test files, enables the `--verify` flag and adds an `assert` to the tests to verify the size check works.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
