### PR TITLE
Fix completion detection

### DIFF
--- a/src/nanopore_sync/cli.py
+++ b/src/nanopore_sync/cli.py
@@ -3,11 +3,18 @@ from pydanclick import from_pydantic
 
 from .config import Config, set_global_config
 from .watchers import watch_new_runs
+from .logging import LOGGER
 
 
 @click.command(context_settings={"show_default": True})
+@click.option(
+    "--log-level",
+    default="INFO",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False),
+    help="Set the logging level for the application."
+)
 @from_pydantic(Config)
-def main(config: Config):
+def main(config: Config, log_level: str) -> None:
     """
     Starts the nanopore sync application using the provided configuration.
     Sets up global configuration and begins watching for new sequencing runs.
@@ -19,4 +26,5 @@ def main(config: Config):
         None
     """
     set_global_config(config)
+    LOGGER.setLevel(log_level)
     watch_new_runs()

--- a/src/nanopore_sync/config.py
+++ b/src/nanopore_sync/config.py
@@ -1,6 +1,7 @@
 
 
 from pydantic import BaseModel, Field, DirectoryPath
+from typing import Literal
 
 from pathlib import Path
 
@@ -40,7 +41,7 @@ class Config(BaseModel):
         required=True,
     )
     run_name_pattern: str = Field(
-        r"[0-9]{8}_[0-9]{4}_[^_]+_[^_]+_[a-f0-9]{8}",
+        r"(?<!/reads/tmp/)[0-9]{8}_[0-9]{4}_[^_]+_[^_]+_[a-f0-9]{8}",
         description="Regex pattern to match nanopore run names",
     )
     completion_signal_pattern: str = Field(


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Improve new run and run completion detection.

### The Why
- Runs were detected in the temporary reads folder
- Run completion was missed if file was moved and not written to.

### The How
- Add negative look-behind for temp reads folder to run name regex
- Trigger sync on `FileMovedEvent` for completion detection
- Make log-level configurable and debug log all events to simplify debugging

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
